### PR TITLE
fix last day power sensor class

### DIFF
--- a/custom_components/linkytic/sensor.py
+++ b/custom_components/linkytic/sensor.py
@@ -322,7 +322,7 @@ async def async_setup_entry(
                     config_title=config_entry.title,
                     config_uniq_id=config_entry.entry_id,
                     serial_reader=serial_reader,
-                    device_class=SensorDeviceClass.CURRENT,
+                    device_class=SensorDeviceClass.POWER,
                     native_unit_of_measurement=UnitOfPower.WATT,  # documentation says unit is Watt but description talks about VoltAmp :/
                 )
             )


### PR DESCRIPTION
Fix the sensor class to remove HASS warning about inconsistent default unit.

2023-06-07 22:36:38.597 WARNING (MainThread)
[homeassistant.components.sensor] Entity
sensor.linky_puissance_maximale_triphasee_atteinte_jour_n_1 (<class 'custom_components.linkytic.sensor.RegularIntSensor'>) is using native unit of measurement 'W' which is not a valid unit for the device class ('current') it is using; expected one of ['A', 'mA']; Please update your configuration if your entity is manually configured, otherwise report it to the custom integration author.