### PR TITLE
sanitize string sensor values

### DIFF
--- a/custom_components/linkytic/sensor.py
+++ b/custom_components/linkytic/sensor.py
@@ -1512,7 +1512,8 @@ class RegularStrSensor(SensorEntity):
                 )
                 self._attr_available = True
         # Save value
-        self._last_value = value
+        # remove useless spaces
+        self._last_value = ' '.join(value.split())
 
 
 class RegularIntSensor(SensorEntity):


### PR DESCRIPTION
* trim left and right spaces
* remove duplicated spaces between words
* example: "    HP  BLEU    " -> "HP BLEU"
* fix for https://github.com/hekmon/linkytic/issues/37