### PR TITLE
Fix "Contact Sec" icon not showing

### DIFF
--- a/custom_components/linkytic/binary_sensor.py
+++ b/custom_components/linkytic/binary_sensor.py
@@ -27,7 +27,7 @@ STATUS_REGISTER_SENSORS = (
         "Contact sec",
         BinarySensorDeviceClass.OPENING,
         "mdi:electric-switch-closed",
-        "mdi-electric-switch",
+        "mdi:electric-switch",
         False,
     ),
     (


### PR DESCRIPTION
Correction d'un petit bug rencontré lors du test de la [v3.0.0-beta4](https://github.com/hekmon/linkytic/releases/tag/v3.0.0-beta4) où l'icone du capteur _Contact sec_ n'était pas affichée.

Avant :
![Capture d'écran 2024-11-15 174632](https://github.com/user-attachments/assets/17f43d84-243c-433d-9b76-ac5d5abb6d72)

Après:
![Capture d'écran 2024-11-15 174833](https://github.com/user-attachments/assets/438ecd11-31c1-4607-b6f0-43cb682abb50)
