### PR TITLE
Remove URL from strings.json

### DIFF
--- a/custom_components/linkytic/config_flow.py
+++ b/custom_components/linkytic/config_flow.py
@@ -34,6 +34,8 @@ from .const import (
     TICMODE_HISTORIC_LABEL,
     TICMODE_STANDARD,
     TICMODE_STANDARD_LABEL,
+    URL_HELP,
+    URL_ISSUES,
 )
 from .serial_reader import CannotConnect, CannotRead, linky_tic_tester
 
@@ -70,46 +72,46 @@ class LinkyTICConfigFlow(ConfigFlow, domain=DOMAIN):  # type:ignore
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle the initial step."""
-        # No input
-        if user_input is None:
-            return self.async_show_form(
-                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
-            )
-        # Validate input
-        await self.async_set_unique_id(DOMAIN + "_" + user_input[SETUP_SERIAL])
-        self._abort_if_unique_id_configured()
-
-        # Search for serial/by-id, which SHOULD be a persistent name to serial interface.
-        _port = await self.hass.async_add_executor_job(
-            usb.get_serial_by_id, user_input[SETUP_SERIAL]
-        )
 
         errors = {}
-        title = user_input[SETUP_SERIAL]
-        try:
-            # Encapsulate the tester function, pyserial rfc2217 implementation have blocking calls.
-            await asyncio.to_thread(
-                linky_tic_tester,
-                device=_port,
-                std_mode=user_input[SETUP_TICMODE] == TICMODE_STANDARD,
+        if user_input is not None:
+            # Validate input
+            await self.async_set_unique_id(DOMAIN + "_" + user_input[SETUP_SERIAL])
+            self._abort_if_unique_id_configured()
+
+            # Search for serial/by-id, which SHOULD be a persistent name to serial interface.
+            _port = await self.hass.async_add_executor_job(
+                usb.get_serial_by_id, user_input[SETUP_SERIAL]
             )
-        except CannotConnect as cannot_connect:
-            _LOGGER.error("%s: can not connect: %s", title, cannot_connect)
-            errors["base"] = "cannot_connect"
-        except CannotRead as cannot_read:
-            _LOGGER.error(
-                "%s: can not read a line after connection: %s", title, cannot_read
-            )
-            errors["base"] = "cannot_read"
-        except Exception as exc:  # pylint: disable=broad-except
-            _LOGGER.exception("Unexpected exception: %s", exc)
-            errors["base"] = "unknown"
-        else:
-            user_input[SETUP_SERIAL] = _port
-            return self.async_create_entry(title=title, data=user_input)
+
+            title = user_input[SETUP_SERIAL]
+            try:
+                # Encapsulate the tester function, pyserial rfc2217 implementation have blocking calls.
+                await asyncio.to_thread(
+                    linky_tic_tester,
+                    device=_port,
+                    std_mode=user_input[SETUP_TICMODE] == TICMODE_STANDARD,
+                )
+            except CannotConnect as cannot_connect:
+                _LOGGER.error("%s: can not connect: %s", title, cannot_connect)
+                errors["base"] = "cannot_connect"
+            except CannotRead as cannot_read:
+                _LOGGER.error(
+                    "%s: can not read a line after connection: %s", title, cannot_read
+                )
+                errors["base"] = "cannot_read"
+            except Exception as exc:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception: %s", exc)
+                errors["base"] = "unknown"
+            else:
+                user_input[SETUP_SERIAL] = _port
+                return self.async_create_entry(title=title, data=user_input)
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+            description_placeholders={"url_help": URL_HELP},
         )
 
     # async def async_step_usb(self, discovery_info: UsbServiceInfo) -> FlowResult:

--- a/custom_components/linkytic/const.py
+++ b/custom_components/linkytic/const.py
@@ -26,6 +26,9 @@ SETUP_THREEPHASE_DEFAULT = False
 
 OPTIONS_REALTIME = "real_time"
 
+URL_HELP = "https://github.com/hekmon/linkytic?tab=readme-ov-file#installation"
+URL_ISSUES = "https://github.com/hekmon/linkytic/issues"
+
 # Protocol configuration
 # #  https://www.enedis.fr/media/2035/download
 

--- a/custom_components/linkytic/strings.json
+++ b/custom_components/linkytic/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "If you need help to fill this form, please check the [readme](https://github.com/hekmon/linkytic/tree/v2).",
+        "description": "If you need help to fill this form, please check the [readme]({url_help}).",
         "data": {
           "serial_device": "Path to the serial device",
           "tic_mode": "TIC mode",
@@ -12,7 +12,6 @@
       }
     },
     "error": {
-      "unsupported_standard": "The standard TIC mode is not supported yet. If you want to help development, feel free to open an issue: https://github.com/hekmon/linkytic/issues/new",
       "cannot_read": "Serial open successfully but an error occured while reading a line (check the logs)",
       "cannot_connect": "Failed to connect (check the logs)",
       "unknown": "[%key:common::config_flow::error::unknown%]"

--- a/custom_components/linkytic/translations/en.json
+++ b/custom_components/linkytic/translations/en.json
@@ -16,7 +16,7 @@
           "tic_mode": "TIC mode",
           "producer_mode": "Producer mode (standard mode only)"
         },
-        "description": "If you need help to fill this form, please check the [readme](https://github.com/hekmon/linkytic/tree/v2)."
+        "description": "If you need help to fill this form, please check the [readme]({url_help})."
       }
     }
   },

--- a/custom_components/linkytic/translations/fr.json
+++ b/custom_components/linkytic/translations/fr.json
@@ -6,8 +6,7 @@
     "error": {
       "cannot_connect": "Erreur de connection (vérifiez les logs)",
       "cannot_read": "La connection série a été ouverte avec succès mais une erreur est survenue pendant la lecture (vérifiez les logs)",
-      "unknown": "Erreur inattendue",
-      "unsupported_standard": "Le mode de transmission standard n'est pas encore supporté. Si vous souhaitez aider le développement, n'hésitez pas à ouvrir une issue: https://github.com/hekmon/linkytic/issues/new"
+      "unknown": "Erreur inattendue"
     },
     "step": {
       "user": {
@@ -17,7 +16,7 @@
           "tic_mode": "Mode TIC",
           "producer_mode": "Mode producteur (seulement pour le mode standard)"
         },
-        "description": "Si vous avez besoin d'aide pour remplir ces champs de configuration, allez voir le fichier [lisezmoi](https://github.com/hekmon/linkytic/tree/v2)."
+        "description": "Si vous avez besoin d'aide pour remplir ces champs de configuration, allez voir le fichier [lisezmoi]({url_help})."
       }
     }
   },


### PR DESCRIPTION
Fix for failing hassfest validation:
`[TRANSLATIONS] Invalid strings.json: the string should not contain URLs, please use description placeholders instead for dictionary value`
And removed unused "unsupported_standard" error, since standard mode is now supported in prerelease mode.