### PR TITLE
fix: replace translations strings url with translations paceholder

### DIFF
--- a/custom_components/linkytic/translations/en.json
+++ b/custom_components/linkytic/translations/en.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "If you need help to fill this form, please check the [readme](https://github.com/hekmon/linkytic/tree/v2).",
+        "description": "If you need help to fill this form, please check the [readme]({url_help}).",
         "data": {
           "serial_device": "Path/URL to the serial device",
           "tic_mode": "TIC mode",

--- a/custom_components/linkytic/translations/fr.json
+++ b/custom_components/linkytic/translations/fr.json
@@ -2,7 +2,7 @@
   "config": {
     "step": {
       "user": {
-        "description": "Si vous avez besoin d'aide pour remplir ces champs de configuration, allez voir le fichier [lisezmoi](https://github.com/hekmon/linkytic/tree/v2).",
+        "description": "Si vous avez besoin d'aide pour remplir ces champs de configuration, allez voir le fichier [lisezmoi]({url_help}).",
         "data": {
           "serial_device": "Chemin/Adresse vers le périphérique série",
           "tic_mode": "Mode TIC",


### PR DESCRIPTION
Re-apply url placeholder in translation strings, that was reverted by a previous commit